### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Run help to get help configuring your setup
 `node app.js help`
 
 
-#Sync your playlists in background and forget about crashes interrupting your download
+# Sync your playlists in background and forget about crashes interrupting your download
 ```shell
 node app.js config -u ramona123 -p m@ric@rmen -d ~/music_download
 # We have now our config ready


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
